### PR TITLE
Fix header to be the older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,10 +20,6 @@
                     </svg>
                     <span>New Chat</span>
                 </button>
-                <div class="header-text">
-                    <h1>Course Materials Assistant</h1>
-                    <p class="subtitle">Ask questions about courses, instructors, and content</p>
-                </div>
                 <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme" title="Toggle theme">
                     <div class="toggle-icon sun-icon">
                         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -64,26 +64,6 @@ header {
     width: 100%;
 }
 
-.header-text {
-    flex: 1;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
-
 /* Theme Toggle Button */
 .theme-toggle {
     position: relative;
@@ -822,14 +802,6 @@ details[open] .suggested-header::before {
     .header-content {
         flex-direction: row;
         gap: 1rem;
-    }
-
-    header h1 {
-        font-size: 1.5rem;
-    }
-
-    .subtitle {
-        font-size: 0.85rem;
     }
 
     .theme-toggle {


### PR DESCRIPTION
Reverts header to simpler version without title and subtitle

- Removed 'Course Materials Assistant' header
- Removed subtitle text
- Kept theme toggle functionality
- Kept new chat button

Closes #2

Generated with [Claude Code](https://claude.ai/code)